### PR TITLE
don't try to use FreeBSD pread wrapper on OSX

### DIFF
--- a/disk.c
+++ b/disk.c
@@ -29,7 +29,7 @@ static int disk_fd = -1;
 
 static int pread_wrapper(int disk_fd, void *p, size_t size, off_t where)
 {
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) && !defined(__APPLE__)
 #define PREAD_BLOCK_SIZE 1024
     /* FreeBSD needs to read aligned whole blocks.
      * TODO: Check what is a safe block size.


### PR DESCRIPTION
OSX also sets **FreeBSD** in the preprocessor, so it tries to use the FBSD-specific code, which doesn't build as apparently __thread isn't supported on OSX:

cc -D__FreeBSD__=10 -D_FILE_OFFSET_BITS=64 -I/usr/local/include/fuse   -DFUSE_USE_VERSION=26 -std=gnu99 -g3 -Wall -Wextra -mmacosx-version-min=10.5 -D_FILE_OFFSET_BITS=64   -c -o disk.o disk.c
disk.c: In function ‘pread_wrapper’:
disk.c:37: error: thread-local storage not supported for this target
