### PR TITLE
Parse arguments from command line

### DIFF
--- a/fuse-main.c
+++ b/fuse-main.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <signal.h>
 #include <execinfo.h>
+#include <stddef.h>
 
 #include "common.h"
 #include "disk.h"
@@ -35,6 +36,37 @@ static struct fuse_operations e4f_ops = {
     .readlink   = op_readlink,
     .init       = op_init,
 };
+
+static struct e4f {
+    char *disk;
+    char *logfile;
+} e4f;
+
+static struct fuse_opt e4f_opts[] = {
+    { "logfile=%s", offsetof(struct e4f, logfile), 0 },
+    FUSE_OPT_END
+};
+
+static int e4f_opt_proc(void *data, const char *arg, int key,
+                        struct fuse_args *outargs)
+{
+    (void) data;
+    (void) outargs;
+
+    switch (key) {
+    case FUSE_OPT_KEY_OPT:
+        return 1;
+    case FUSE_OPT_KEY_NONOPT:
+        if (!e4f.disk) {
+            e4f.disk = strdup(arg);
+            return 0;
+        }
+        return 1;
+    default:
+        fprintf(stderr, "internal error\n");
+        abort();
+    }
+}
 
 void signal_handle_sigsegv(int signal)
 {
@@ -58,29 +90,42 @@ void signal_handle_sigsegv(int signal)
 
 int main(int argc, char *argv[])
 {
-    if (argc < 3) {
-        fprintf(stderr, "Usage: %s fs mountpoint\n", argv[0]);
-        return EXIT_FAILURE;
-    }
+    int res;
+    struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
 
     if (signal(SIGSEGV, signal_handle_sigsegv) == SIG_ERR) {
         fprintf(stderr, "Failed to initialize signals\n");
         return EXIT_FAILURE;
     }
 
-    if (logging_open(argc == 4 ? argv[3] : DEFAULT_LOG_FILE) < 0) {
+    // Default options
+    e4f.disk = NULL;
+    e4f.logfile = DEFAULT_LOG_FILE;
+
+    if (fuse_opt_parse(&args, &e4f, e4f_opts, e4f_opt_proc) == -1) {
+        return EXIT_FAILURE;
+    }
+
+    if (!e4f.disk) {
+        fprintf(stderr, "Usage: %s <disk> <mountpoint>\n", argv[0]);
+        exit(1);
+    }
+
+    if (logging_open(e4f.logfile) < 0) {
         fprintf(stderr, "Failed to initialize logging\n");
         return EXIT_FAILURE;
     }
 
-    if (disk_open(argv[1]) < 0) {
-        perror("disk_open");
+    if (disk_open(e4f.disk) < 0) {
+        fprintf(stderr, "disk_open: %s: %s\n", e4f.disk,
+                strerror(errno));
         return EXIT_FAILURE;
     }
 
-    argc = 2;
-    argv[1] = argv[2];
-    argv[2] = NULL;
+    res = fuse_main(args.argc, args.argv, &e4f_ops, NULL);
 
-    return fuse_main(argc, argv, &e4f_ops, NULL);
+    fuse_opt_free_args(&args);
+    free(e4f.disk);
+
+    return res;
 }   


### PR DESCRIPTION
Parse command line parameters passed to the -o argument using
fuse_opt_parse(). The log file is no longer given as an additional
parameter, but needs to be passed using -o logfile=FILE.
