### PR TITLE
Reset inode_idx to 0 if the entry cannot be found.

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -235,6 +235,7 @@ uint32_t inode_get_idx_by_path(const char *path)
 
         /* Couldn't find the entry at all */
         if (dentry == NULL) {
+            inode_idx = 0;
             break;
         }
     } while((path = strchr(path, '/')));


### PR DESCRIPTION
This fixes a problem whereby requesting a non-existent path would still return a valid inode index. In particular, inode_idx = 2 (ROOT_INODE_N) would be returned when attempting to access a non-existent path in the root mount point. This, in turn, would cause commands such as "ls <non_existent_path>" to display the contents of the root directory.

I found this problem in Mac OS X (as of 10.10.3). I haven't tested other OSs.