### PR TITLE
Use size_t explicitly to make sure we get 64-bit values on 64-bit systems

### DIFF
--- a/super.h
+++ b/super.h
@@ -7,12 +7,12 @@
 
 #include "common.h"
 
-#define BLOCK_SIZE                              (super_block_size())
+#define BLOCK_SIZE                              ((size_t)super_block_size())
 #define BLOCKS2BYTES(__blks)                    (((uint64_t)(__blks)) * BLOCK_SIZE)
 #define BYTES2BLOCKS(__bytes)                   ((__bytes) / BLOCK_SIZE + ((__bytes) % BLOCK_SIZE ? 1 : 0))
 
 #define MALLOC_BLOCKS(__blks)                   (malloc(BLOCKS2BYTES(__blks)))
-#define ALIGN_TO_BLOCKSIZE(__n)                 (ALIGN_TO(__n, BLOCK_SIZE))
+#define ALIGN_TO_BLOCKSIZE(__n)                 (ALIGN_TO((size_t)__n, BLOCK_SIZE))
 
 #define BOOT_SECTOR_SIZE            0x400
 


### PR DESCRIPTION
This was the only change I needed to successfully mount a 12T ext4 filesystem (with 64k block size) and access a 9T file on it (an iSCSI LUN image).  Without size_t in these places, a number of operations were being truncated to 32 bit (and in some cases sign-extended), causing all sorts of weirdness to happen.

I don't know if it's better to just change super_block_size() to return a size_t, but the ALIGN_TO_BLOCKSIZE cast probably has to stay, or all callers of it need to be audited to make sure they're passing in a 64-bit value.
