### PR TITLE
Update README.md for new homebrew support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ that ext4fuse is read-only also means that it's completely safe to use.
 ### OS X 
 If you use OS X I suggest you rely on the [homebrew project](http://mxcl.github.com/homebrew/).
 
-Once you have homebrew installed, simply type:
+Once you have homebrew installed, simply type the following three commands:
+
+`$ brew tap homebrew/fuse`
+
+`$ brew install Caskroom/cask/osxfuse`
 
 `$ brew install ext4fuse`
 


### PR DESCRIPTION
Homebrew seems to have moved the all of the fuse recipes to a separate "tap".

Thus there are some new instructions necessary to get ext4fuse installed.