### PR TITLE
Update install instructions to install osxfuse cask.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ If you use OS X I suggest you rely on the [homebrew project](http://mxcl.github.
 
 Once you have homebrew installed, simply type the following three commands:
 
-`$ brew tap homebrew/fuse`
-
-`$ brew install Caskroom/cask/osxfuse`
+`$ brew cask install osxfuse`
 
 `$ brew install ext4fuse`
 


### PR DESCRIPTION
Following the install instructions in the current README gives me a warning because it seems the old tap isn't available now. Instead, I installed the `osxfuse` cask, then installed `ext4fuse`, and it worked. It removes one step from the install instructions, too :)