### PR TITLE
Fix homebrew command count

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ that ext4fuse is read-only also means that it's completely safe to use.
 ### OS X 
 If you use OS X I suggest you rely on the [homebrew project](http://mxcl.github.com/homebrew/).
 
-Once you have homebrew installed, simply type the following three commands:
+Once you have homebrew installed, simply type the following two commands:
 
 `$ brew cask install osxfuse`
 


### PR DESCRIPTION
The FUSE implementations in Homebrew were previously in a seperate,
tap (homebrew/fuse). They were moved to homebrew-core, and the
install instructions in gerard/ext4fuse were fixed. However, it
still mentions that three instead of two commands are needed. This
commit fixed that.