### PR TITLE
Round up when calculating number of block groups

### DIFF
--- a/super.c
+++ b/super.c
@@ -27,7 +27,7 @@ static uint64_t super_block_group_size(void)
 
 static uint32_t super_n_block_groups(void)
 {
-    uint32_t n = super.s_blocks_count_lo / super.s_blocks_per_group;
+    uint32_t n = (super.s_blocks_count_lo + super.s_blocks_per_group - 1) / super.s_blocks_per_group;
     return n ? n : 1;
 }
 


### PR DESCRIPTION
When trying to read a filesystem with a super.s_blocks_count_lo of 341,684, a super.s_blocks_per_group of 32,768, and the following attributes, I get the following error:

[info] [super_fill:59] BLOCK SIZE: 4096
[info] [super_fill:60] BLOCK GROUP SIZE: 134217728
[info] [super_fill:61] N BLOCK GROUPS: 10
[info] [super_fill:62] INODE SIZE: 256
[info] [super_fill:63] INODES PER GROUP: 272
[info] [super_fill:64] INODES: 2992

. . . 

[warn] [super_group_inode_table_offset:76] ASSERT FAIL: n_group < super_n_block_groups()

I believe this is because the number of block groups should actually be rounded up to 11.  10 block groups would only provide for 327,680 blocks, and thus when trying to read an inode for the 11th block, the assertion fails.  This change corrects the calculation of super_n_block_groups().

ext4fuse appears to read the filesystem properly after this change is made.