### PR TITLE
update brew cask install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you use OS X I suggest you rely on the [homebrew project](http://mxcl.github.
 
 Once you have homebrew installed, simply type the following two commands:
 
-`$ brew cask install osxfuse`
+`$ brew install --cask osxfuse`
 
 `$ brew install ext4fuse`
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524