### PR TITLE
update brew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you use OS X I suggest you rely on the [homebrew project](http://mxcl.github.
 
 Once you have homebrew installed, simply type the following two commands:
 
-`$ brew cask install osxfuse`
+`$ brew install osxfuse`
 
 `$ brew install ext4fuse`
 


### PR DESCRIPTION
Cask in invalid option for brew now, it's deprecated: https://docs.brew.sh/Deprecating-Disabling-and-Removing-Casks

```
❯ brew cask install osxfuse
Example usage:
  brew search TEXT|/REGEX/
  brew info [FORMULA|CASK...]
  brew install FORMULA|CASK...
  brew update
  brew upgrade [FORMULA|CASK...]
  brew uninstall FORMULA|CASK...
  brew list [FORMULA|CASK...]

Troubleshooting:
  brew config
  brew doctor
  brew install --verbose --debug FORMULA|CASK

Contributing:
  brew create URL [--no-fetch]
  brew edit [FORMULA|CASK...]

Further help:
  brew commands
  brew help [COMMAND]
  man brew
  https://docs.brew.sh

Error: Invalid usage: Unknown command: brew cask
```